### PR TITLE
fix: add support for mono repo

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,10 +3,11 @@
  * https://github.com/nuxt/eslint-plugin-nuxt/issues/173
  */
 import {fileURLToPath} from 'url';
-import {addTemplate, defineNuxtModule} from '@nuxt/kit';
+import {addTemplate, defineNuxtModule, useLogger} from '@nuxt/kit';
 import {getUtils} from './utils.mjs';
 import {resolveModuleExportNames} from 'mlly';
 
+const logger = useLogger("nuxt:esLint-globals");
 
 const modulePath = fileURLToPath(import.meta.url);
 
@@ -125,7 +126,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       addTemplate(templateOptions);
 
-      console.log(`\nESLint globals file generated at ${paths.display}\n`);
+      logger.success(`ESLint globals file generated at ${paths.display}`);
     });
   },
 });


### PR DESCRIPTION
Hi! 👋

I really like this module — it's simple, effective, and keeps my WebStorm IDE very happy. Thanks for creating it!

I ran into a small issue using it in a monorepo setup where it couldn't find `node_modules` in the parent directory. I’ve added a fix for that and also adjusted the logging to align more with patterns I've seen in other Nuxt modules.

Let me know if you'd like anything changed or adjusted. Thanks again!

The original error looks like this:
```
ENOENT: no such file or directory, open '/home/projects/awesome/app/node_modules/nitropack/dist/runtime/index.mjs'                                                                                                                                                                                                                                      9:12:56 AM

    at async open (node:internal/fs/promises:633:25)
    at async readFile (node:internal/fs/promises:1237:14)
    at async Promise.all (index 0)
    at async getNitroImports (/home/projects/awesome/node_modules/nuxt-eslint-globals/dist/module.mjs:55:26)
    at async /home/projects/awesome/node_modules/nuxt-eslint-globals/dist/module.mjs:278:55
    at async setup (/home/projects/awesome/node_modules/nuxt/dist/shared/nuxt.MnbV098l.mjs:3760:5)
    at async normalizedModule (/home/projects/awesome/node_modules/@nuxt/kit/dist/index.mjs:2169:17)
    at async installModule (/home/projects/awesome/node_modules/@nuxt/kit/dist/index.mjs:2494:276)
    at async initNuxt (/home/projects/awesome/node_modules/nuxt/dist/shared/nuxt.MnbV098l.mjs:5850:5)
    at async loadNuxt (/home/projects/awesome/node_modules/nuxt/dist/shared/nuxt.MnbV098l.mjs:6073:5)
    at async loadNuxt (/home/projects/awesome/node_modules/@nuxt/kit/dist/index.mjs:2720:19)
    at async Object.run (/home/projects/awesome/node_modules/@nuxt/cli/dist/chunks/prepare.mjs:30:18)
    at async runCommand (/home/projects/awesome/node_modules/citty/dist/index.mjs:316:16)
    at async runCommand (/home/projects/awesome/node_modules/citty/dist/index.mjs:307:11)
    at async runMain (/home/projects/awesome/node_modules/citty/dist/index.mjs:445:7)
                                                                                                                                                                                                                                                                                                                                                                                                              9:12:56 AM
ESLint globals file generated at /home/projects/awesome.nuxt/.eslint.globals.mjs

```

It should be looking in `/home/projects/awesome/node_modules` instead of `/home/projects/awesome/app/node_modules`
Also, the display for generated file is off.

After my tweaks:
```
$ npx nuxt prepare
ℹ Using default Tailwind CSS file                                    nuxt:tailwindcss 11:01:49 AM
ℹ nuxt-auth setup starting                                              sidebase-auth 11:01:49 AM
✔ nuxt-auth setup done                                                  sidebase-auth 11:01:49 AM
✔ ESLint globals file generated at .nuxt/.eslint.globals.mjs      nuxt:eSLint-globals 11:01:50 AM
✔ Types generated in .nuxt                                                       nuxi 11:01:50 AM
```

Tested with custom output dir as an absolute path.
`["nuxt-eslint-globals", { outputDir: "/tmp"}]`
```
$ npx nuxt prepare
ℹ Using default Tailwind CSS file                                    nuxt:tailwindcss 11:03:19 AM
ℹ nuxt-auth setup starting                                              sidebase-auth 11:03:19 AM
✔ nuxt-auth setup done                                                  sidebase-auth 11:03:19 AM
✔ ESLint globals file generated at /tmp/.eslint.globals.mjs       nuxt:eSLint-globals 11:03:20 AM
✔ Types generated in .nuxt                                                       nuxi 11:03:20 AM
```

Tested with custim relative path.
` ["nuxt-eslint-globals", { outputDir: "./my-stuff"}]`
```
$ npx nuxt prepare
ℹ Using default Tailwind CSS file                                    nuxt:tailwindcss 11:04:34 AM
ℹ nuxt-auth setup starting                                              sidebase-auth 11:04:34 AM
✔ nuxt-auth setup done                                                  sidebase-auth 11:04:34 AM
✔ ESLint globals file generated at my-stuff/.eslint.globals.mjs   nuxt:eSLint-globals 11:04:35 AM
✔ Types generated in .nuxt                                                       nuxi 11:04:35 AM
```
